### PR TITLE
Adds webget and websearch tools.

### DIFF
--- a/main.go
+++ b/main.go
@@ -318,7 +318,10 @@ func runFrontendServer(ctx context.Context, config *AppConfig, modelParams []Mod
 			}
 		}()
 
-		return c.SendStatus(fiber.StatusOK)
+		progressErr := "<div name='sse-messages' class='w-100' id='sse-messages' hx-ext='sse' sse-connect='/sseupdates' sse-swap='message'></div>"
+
+		return c.SendString(progressErr)
+		// return c.SendStatus(fiber.StatusOK)
 	})
 
 	app.Post("/chattemplates", func(c *fiber.Ctx) error {

--- a/main.go
+++ b/main.go
@@ -435,6 +435,23 @@ func runFrontendServer(ctx context.Context, config *AppConfig, modelParams []Mod
 		return c.SendStatus(fiber.StatusNoContent)
 	})
 
+	// Multi web page retrieval via local ChromeDP
+	app.Get("/dpsearch", func(c *fiber.Ctx) error {
+
+		urls := []string{}
+		query := c.Query("q")
+		res := web.SearchDuckDuckGo(query)
+		if len(res) == 0 {
+			return c.Status(fiber.StatusInternalServerError).SendString("Error retrieving search results")
+		}
+
+		// Remove youtube results
+		urls = append(urls, res...)
+
+		// Send results as json object
+		return c.Status(fiber.StatusOK).JSON(fiber.Map{"urls": urls})
+	})
+
 	app.Get("/sseupdates", func(c *fiber.Ctx) error {
 		c.Set("Content-Type", "text/event-stream")
 		c.Set("Cache-Control", "no-cache")

--- a/main.go
+++ b/main.go
@@ -491,8 +491,6 @@ func runFrontendServer(ctx context.Context, config *AppConfig, modelParams []Mod
 		// Extract the chat_message value
 		chatMessage := wsMessage.ChatMessage
 
-		pterm.Info.Println("Chat message:", chatMessage)
-
 		var document string
 
 		url := web.ExtractURLs(chatMessage)
@@ -566,6 +564,16 @@ func runFrontendServer(ctx context.Context, config *AppConfig, modelParams []Mod
 
 		// Extract the chat_message value
 		chatMessage := wsMessage.ChatMessage
+
+		var document string
+
+		url := web.ExtractURLs(chatMessage)
+
+		if len(url) > 0 {
+			document, _ = web.WebGetHandler(url[0])
+			document = fmt.Sprintf("%s\nUse the previous unformation as reference for the following:\n", document)
+			chatMessage = fmt.Sprintf("%s%s", document, chatMessage)
+		}
 
 		// Process the message (existing logic)
 		cpt := llm.GetSystemTemplate(chatMessage)

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -3,7 +3,6 @@ package web
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"log"
 	"net/url"
@@ -13,12 +12,31 @@ import (
 	"time"
 
 	"github.com/chromedp/cdproto/cdp"
-	"github.com/chromedp/cdproto/dom"
 	"github.com/chromedp/chromedp"
 	"github.com/chromedp/chromedp/kb"
 	"github.com/pterm/pterm"
 	"golang.org/x/net/html"
 	"golang.org/x/net/html/atom"
+)
+
+var (
+	unwantedURLs = []string{
+		"youtube.com",
+		"wired.com",
+		"techcrunch.com",
+		"wsj.com",
+		"cnn.com",
+		"nytimes.com",
+		"forbes.com",
+		"businessinsider.com",
+		"theverge.com",
+		"thehill.com",
+		"theatlantic.com",
+		"foxnews.com",
+		"theguardian.com",
+		"nbcnews.com",
+		// Add more URLs to block from search results
+	}
 )
 
 func WebGetHandler(url string) (string, error) {
@@ -167,76 +185,113 @@ func isInlineElement(n *html.Node) bool {
 }
 
 // SearchDuckDuckGo performs a search on DuckDuckGo and retrieves the HTML of the first page of results.
-func SearchDuckDuckGo(chromeUrl, query string) []string {
-	instanceUrl := chromeUrl
-
-	// Create allocator context for using existing Chrome instance
-	allocatorCtx, cancel := chromedp.NewRemoteAllocator(context.Background(), instanceUrl)
+func SearchDuckDuckGo(query string) []string {
+	// Initialize headless Chrome
+	opts := append(chromedp.DefaultExecAllocatorOptions[:],
+		chromedp.Flag("headless", true),
+	)
+	allocCtx, cancel := chromedp.NewExecAllocator(context.Background(), opts...)
 	defer cancel()
-
-	// Create context with logging for actions performed by chromedp
-	ctx, cancel := chromedp.NewContext(allocatorCtx, chromedp.WithLogf(log.Printf))
+	ctx, cancel := chromedp.NewContext(allocCtx)
 	defer cancel()
 
 	// Set a timeout for the entire operation
 	ctx, cancel = context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	// Run tasks to perform the search and get HTML content
 	var nodes []*cdp.Node
+	var resultURLs []string
+
+	// Perform the search on DuckDuckGo
 	err := chromedp.Run(ctx,
 		chromedp.Navigate(`https://duckduckgo.com/`),
 		chromedp.WaitVisible(`input[name="q"]`, chromedp.ByQuery),
 		chromedp.SendKeys(`input[name="q"]`, query+kb.Enter, chromedp.ByQuery),
-
-		// Wait for JavaScript to load the search results
-		chromedp.Sleep(5*time.Second),
-
-		// Wait for search results to be visible
+		chromedp.Sleep(5*time.Second), // Wait for JavaScript to load the search results
 		chromedp.WaitVisible(`button[id="more-results"]`, chromedp.ByQuery),
-
 		chromedp.Nodes(`a`, &nodes, chromedp.ByQueryAll),
+	)
+	if err != nil {
+		log.Printf("Error during search: %v", err)
+		return nil
+	}
 
+	// Process the search results
+	err = chromedp.Run(ctx,
 		chromedp.ActionFunc(func(c context.Context) error {
-			// depth -1 for the entire subtree
-			// do your best to limit the size of the subtree
-			dom.RequestChildNodes(nodes[0].NodeID).WithDepth(-1).Do(c)
-
-			// Compile the regex outside of the loop for efficiency
 			re, err := regexp.Compile(`^http[s]?://`)
 			if err != nil {
 				return err
 			}
 
 			uniqueUrls := make(map[string]bool)
-
-			// loop through the nodes and print the href attributes of a elements
 			for _, n := range nodes {
 				for _, attr := range n.Attributes {
-					if re.MatchString(attr) {
-						// Check if URL contains 'duckduckgo'
-						if !strings.Contains(attr, "duckduckgo") {
-							uniqueUrls[attr] = true
-						}
+					if re.MatchString(attr) && !strings.Contains(attr, "duckduckgo") {
+						uniqueUrls[attr] = true
 					}
 				}
 			}
 
-			// Convert map keys to slice
-			resultURLs = make([]string, 0, len(uniqueUrls))
 			for url := range uniqueUrls {
 				resultURLs = append(resultURLs, url)
-			}
-
-			for _, l := range resultURLs {
-				fmt.Println(l)
 			}
 
 			return nil
 		}),
 	)
+
 	if err != nil {
-		return resultURLs
+		log.Printf("Error processing results: %v", err)
+		return nil
+	}
+
+	// Remove unwanted URLs
+	resultURLs = RemoveUnwantedURLs(resultURLs)
+
+	// Only return the top 3 results
+	resultURLs = resultURLs[:3]
+
+	return resultURLs
+}
+
+// GetSearchResults loops over a list of URLs and retrieves the HTML of each page.
+func GetSearchResults(urls []string) string {
+	var resultHTML string
+
+	for _, url := range urls {
+		res, err := WebGetHandler(url)
+		if err != nil {
+			pterm.Error.Printf("Error getting search result: %v", err)
+			continue
+		}
+
+		if res != "" {
+			resultHTML += res
+		}
+
+		// time.Sleep(5 * time.Second)
+	}
+
+	return resultHTML
+}
+
+// RemoveUnwantedURLs removes unwanted URLs from the list of URLs.
+func Contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
+func RemoveUnwantedURLs(urls []string) []string {
+	var resultURLs []string
+	for _, url := range urls {
+		if !Contains(unwantedURLs, url) {
+			resultURLs = append(resultURLs, url)
+		}
 	}
 
 	return resultURLs

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -35,6 +35,8 @@ var (
 		"foxnews.com",
 		"theguardian.com",
 		"nbcnews.com",
+		"msn.com",
+		"sciencedaily.com",
 		// Add more URLs to block from search results
 	}
 )
@@ -249,8 +251,8 @@ func SearchDuckDuckGo(query string) []string {
 	// Remove unwanted URLs
 	resultURLs = RemoveUnwantedURLs(resultURLs)
 
-	// Only return the top 3 results
-	resultURLs = resultURLs[:3]
+	// Only return the top n results
+	resultURLs = resultURLs[:1]
 
 	return resultURLs
 }

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -227,3 +227,4 @@ span.hljs-regexp {
 span.hljs-tag {
     color: #f92672;
 }
+

--- a/public/js/events.js
+++ b/public/js/events.js
@@ -33,7 +33,7 @@ async function highlightSelectedModels() {
 
     // Apply 'card-selected' class to each selected model's card
     selectedModelNames.forEach(modelName => {
-      const modelCard = document.querySelector(`.card[data-model-name="${modelName}"]`);
+      const modelCard = document.querySelector(`[data-model-name="${modelName}"]`);
       if (modelCard) {
         modelCard.classList.add('card-selected');
       }

--- a/public/js/events.js
+++ b/public/js/events.js
@@ -49,6 +49,7 @@ let selectedModels = [];
 
 // Call getSelectedModels when the DOM content is fully loaded
 document.addEventListener('DOMContentLoaded', () => {
+
   promptViewHeight = document.getElementById('prompt-view').offsetHeight;
   getSelectedModels();
   const observer = new MutationObserver(mutationCallback);

--- a/public/js/workflows.js
+++ b/public/js/workflows.js
@@ -1,3 +1,9 @@
+// List of tool names enabled by default:
+var enabledTools = [
+  // "webget", // Retrieves a single page from a given url
+  // "websearch", // Searches a given query and returns n urls to pass to webget tool
+];
+
 const uploadButton = document.getElementById('upload');
 const fileInput = document.getElementById('file-input');
 

--- a/public/templates/chat.html
+++ b/public/templates/chat.html
@@ -1,3 +1,159 @@
+<style>
+  .loadership_JTACT {
+    display: flex;
+    position: relative;
+    width: 68px;
+    height: 68px;
+  }
+
+  .loadership_JTACT div {
+    animation: loadership_JTACT_roller 1.2s infinite;
+    animation-timing-function: cubic-bezier(0.5, 0, 0.5, 1);
+    transform-origin: 34px 34px;
+  }
+
+  .loadership_JTACT div:after {
+    content: " ";
+    display: block;
+    position: absolute;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #ffffff;
+  }
+
+  .loadership_JTACT div:nth-child(1) {
+    animation-delay: 0.00s;
+  }
+
+  .loadership_JTACT div:nth-child(1):after {
+    top: 60px;
+    left: 30px;
+  }
+
+
+  .loadership_JTACT div:nth-child(2) {
+    animation-delay: -0.04s;
+  }
+
+  .loadership_JTACT div:nth-child(2):after {
+    top: 56px;
+    left: 45px;
+  }
+
+
+  .loadership_JTACT div:nth-child(3) {
+    animation-delay: -0.07s;
+  }
+
+  .loadership_JTACT div:nth-child(3):after {
+    top: 45px;
+    left: 56px;
+  }
+
+
+  .loadership_JTACT div:nth-child(4) {
+    animation-delay: -0.11s;
+  }
+
+  .loadership_JTACT div:nth-child(4):after {
+    top: 30px;
+    left: 60px;
+  }
+
+
+  .loadership_JTACT div:nth-child(5) {
+    animation-delay: -0.14s;
+  }
+
+  .loadership_JTACT div:nth-child(5):after {
+    top: 15px;
+    left: 56px;
+  }
+
+
+  .loadership_JTACT div:nth-child(6) {
+    animation-delay: -0.18s;
+  }
+
+  .loadership_JTACT div:nth-child(6):after {
+    top: 4px;
+    left: 45px;
+  }
+
+
+  .loadership_JTACT div:nth-child(7) {
+    animation-delay: -0.22s;
+  }
+
+  .loadership_JTACT div:nth-child(7):after {
+    top: 0px;
+    left: 30px;
+  }
+
+
+  .loadership_JTACT div:nth-child(8) {
+    animation-delay: -0.25s;
+  }
+
+  .loadership_JTACT div:nth-child(8):after {
+    top: 4px;
+    left: 15px;
+  }
+
+
+  .loadership_JTACT div:nth-child(9) {
+    animation-delay: -0.29s;
+  }
+
+  .loadership_JTACT div:nth-child(9):after {
+    top: 15px;
+    left: 4px;
+  }
+
+
+  .loadership_JTACT div:nth-child(10) {
+    animation-delay: -0.32s;
+  }
+
+  .loadership_JTACT div:nth-child(10):after {
+    top: 30px;
+    left: 0px;
+  }
+
+
+  .loadership_JTACT div:nth-child(11) {
+    animation-delay: -0.36s;
+  }
+
+  .loadership_JTACT div:nth-child(11):after {
+    top: 45px;
+    left: 4px;
+  }
+
+
+  .loadership_JTACT div:nth-child(12) {
+    animation-delay: -0.40s;
+  }
+
+  .loadership_JTACT div:nth-child(12):after {
+    top: 56px;
+    left: 15px;
+  }
+
+
+
+  @keyframes loadership_JTACT_roller {
+    0% {
+      transform: rotate(0deg);
+    }
+
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+</style>
+
 <div name="chat-{{.turnID}}" id="chat-{{.turnID}}" hx-ext="ws" ws-connect="{{.wsRoute}}">
   <div class="row">
     <div id="prompt-{{.turnID}}" class="user-prompt rounded-2 mt-3 pb-3">
@@ -23,6 +179,20 @@
       <!-- Messages received from WebSocket will be appended here -->
       <div name="chat-{{.turnID}}" id="response-content-{{.turnID}}" hx-trigger="load, customEndOfStream"
         hx-on:load="highlight()">
+        <div class="loadership_JTACT">
+          <div></div>
+          <div></div>
+          <div></div>
+          <div></div>
+          <div></div>
+          <div></div>
+          <div></div>
+          <div></div>
+          <div></div>
+          <div></div>
+          <div></div>
+          <div></div>
+        </div>
       </div>
     </div>
   </div>

--- a/public/templates/chat.html
+++ b/public/templates/chat.html
@@ -8,11 +8,10 @@
       <form id="hidden-form-{{.turnID}}" style="display:none;" hx-trigger="load" ws-send>
         <!-- Get the selectedModels in localStorage and send over websocket -->
         <input type="hidden" name="model" value="{{.model}}">
-        <input type="hidden" name="prompt" value="{{.prompt}}">
         <input type="hidden" name="chat_message" value="{{.message}}">
       </form>
       <div>
-        <span class="message-content mx-1">{{.prompt}}</span>
+        <span class="message-content mx-1">{{.message}}</span>
       </div>
     </div>
   </div>
@@ -28,6 +27,7 @@
     </div>
   </div>
 </div>
+
 <script>
   htmx.on("htmx:wsOnClose", function (evt) {
     highlight();

--- a/public/templates/index.html
+++ b/public/templates/index.html
@@ -144,7 +144,7 @@
       <div id="info" class="col-2 mt-2 pt-1">
 
         <!-- TODO: MOVE DOWNLOAD PROGRESS TO MODEL CARD -->
-        <div class="toast-container position-relative top-0 end-0 p-3">
+        <!-- <div class="toast-container position-relative top-0 end-0 p-3">
           <div id="download-toast" class="toast" role="alert" aria-live="assertive" aria-atomic="true"
             data-bs-autohide="false">
             <div class="m-2">
@@ -157,7 +157,7 @@
               </div>
             </div>
           </div>
-        </div>
+        </div> -->
         
       </div>
     </div>

--- a/public/templates/index.html
+++ b/public/templates/index.html
@@ -49,6 +49,7 @@
   <div id="content" class="container-fluid overflow-x-hidden">
     <div class="row">
       <div class="col-2 p-4 fixed-top">
+        <!-- TODO: Convert the tool pane to a stack: https://www.gethalfmoon.com/docs/stacks/ -->
         <div class="row">
           <button class="btn fw-medium" data-bs-toggle="/">
             <span class="fs-4">Et<svg class="" width="16" height="16" viewBox="0 0 24 24"
@@ -62,7 +63,8 @@
         </div>
         <div class="row mt-5">
           <!-- MODELS -->
-          <button class="btn" hx-post="/modelcards" hx-target="#chat-view" hx-swap="afterbegin transition:true">
+          <button class="btn" hx-post="/modelcards" hx-target="#chat-view" hx-swap="afterbegin transition:true"
+            data-bs-toggle="tooltip" data-bs-title="Language Models">
             <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
               <g fill="none">
                 <path stroke="#ffffff" stroke-linecap="round" stroke-width="1.5"
@@ -77,7 +79,7 @@
         </div>
         <!-- WEB PAGE RETRIEVAL -->
         <div class="row mt-5">
-          <button id="webget-btn" class="btn">
+          <button id="webget-btn" class="btn" data-bs-toggle="tooltip" data-bs-title="Web Retrieval">
             <svg id="webget" width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
               <g fill="none" stroke="#ffffff" stroke-width="1.5">
                 <path
@@ -89,7 +91,8 @@
         </div>
         <!-- WEB SEARCH -->
         <div class="row mt-5">
-          <button class="btn">
+          <button id="websearchBtn" class="btn" hx-post="/tool/websearch" hx-swap="none" data-bs-toggle="tooltip"
+            data-bs-title="Web Search">
             <svg id="websearch" width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
               <path fill="#ffffff" fill-rule="evenodd"
                 d="M9.944 3.25h4.112c1.838 0 3.294 0 4.433.153c1.172.158 2.121.49 2.87 1.238c.748.749 1.08 1.698 1.238 2.87c.09.673.127 1.456.142 2.363a.755.755 0 0 1 .004.23c.007.566.007 1.178.007 1.84V13a.75.75 0 0 1-1.5 0v-1c0-.446 0-.862-.002-1.25H2.752c-.002.388-.002.804-.002 1.25c0 1.907.002 3.262.14 4.29c.135 1.005.389 1.585.812 2.008c.423.423 1.003.677 2.009.812c1.028.138 2.382.14 4.289.14h3a.75.75 0 0 1 0 1.5H9.944c-1.838 0-3.294 0-4.433-.153c-1.172-.158-2.121-.49-2.87-1.238c-.748-.749-1.08-1.698-1.238-2.87c-.153-1.14-.153-2.595-.153-4.433v-.112c0-.662 0-1.274.007-1.84a.757.757 0 0 1 .003-.23c.016-.907.053-1.69.143-2.363c.158-1.172.49-2.121 1.238-2.87c.749-.748 1.698-1.08 2.87-1.238c1.14-.153 2.595-.153 4.433-.153m-7.168 6h18.448a15.6 15.6 0 0 0-.114-1.54c-.135-1.005-.389-1.585-.812-2.008c-.423-.423-1.003-.677-2.009-.812c-1.027-.138-2.382-.14-4.289-.14h-4c-1.907 0-3.261.002-4.29.14c-1.005.135-1.585.389-2.008.812c-.423.423-.677 1.003-.812 2.009c-.06.445-.094.952-.114 1.539M18 14.75a2.25 2.25 0 1 0 0 4.5a2.25 2.25 0 0 0 0-4.5M14.25 17a3.75 3.75 0 1 1 6.879 2.068l.901.902a.75.75 0 1 1-1.06 1.06l-.902-.901A3.75 3.75 0 0 1 14.25 17m-9-1a.75.75 0 0 1 .75-.75h4a.75.75 0 0 1 0 1.5H6a.75.75 0 0 1-.75-.75"
@@ -99,7 +102,7 @@
         </div>
         <!-- CODE SANDBOX -->
         <div class="row mt-5">
-          <button class="btn">
+          <button class="btn" data-bs-toggle="tooltip" data-bs-title="Code Sandbox">
             <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
               <g fill="none" stroke="#ffffff" stroke-linecap="round" stroke-width="1.5">
                 <path
@@ -110,9 +113,9 @@
             </svg>
           </button>
         </div>
-        <!-- SDXL -->
+        <!-- Image Generation -->
         <div id="txt2img" class="row mt-5">
-          <button class="btn" type="button" onclick="toastDisplay()">
+          <button class="btn" type="button" data-bs-toggle="tooltip" data-bs-title="Image Generation">
             <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
               <path fill="#FFFFFF"
                 d="M17.29 11.969a1.33 1.33 0 0 1-1.322 1.337a1.33 1.33 0 0 1-1.323-1.337a1.33 1.33 0 0 1 1.323-1.338c.73 0 1.323.599 1.323 1.338Z" />
@@ -126,7 +129,7 @@
         </div>
         <!-- SETTINGS -->
         <div class="row mt-5">
-          <button class="btn" data-bs-toggle="modal" data-bs-target="#modal-settings">
+          <button class="btn" data-bs-target="#modal-settings" data-bs-toggle="tooltip" data-bs-title="Settings">
             <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
               <g fill="none" stroke="#ffffff" stroke-width="1.5">
                 <circle cx="12" cy="12" r="3" />
@@ -158,7 +161,7 @@
             </div>
           </div>
         </div> -->
-        
+
       </div>
     </div>
     <div class="">
@@ -269,6 +272,14 @@
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script src="js/events.js"></script>
   <script src="js/workflows.js"></script>
+  <script>
+    const tooltipTriggerList = document.querySelectorAll(
+      "[data-bs-toggle='tooltip']"
+    );
+    const tooltipList = [...tooltipTriggerList].map(
+      (tooltipTriggerEl) => new bootstrap.Tooltip(tooltipTriggerEl)
+    );
+  </script>
 </body>
 
 </html>

--- a/public/templates/model.html
+++ b/public/templates/model.html
@@ -22,9 +22,10 @@
                 d="M12.226 3.5c-2.75 0-4.964 2.2-4.964 4.897c0 .462.065.909.185 1.331c.497.144.963.36 1.383.64a.75.75 0 1 1-.827 1.25a3.54 3.54 0 0 0-1.967-.589c-1.961 0-3.536 1.57-3.536 3.486C2.5 16.43 4.075 18 6.036 18a.75.75 0 0 1 0 1.5C3.263 19.5 1 17.276 1 14.515c0-2.705 2.17-4.893 4.864-4.983a6.366 6.366 0 0 1-.102-1.135C5.762 4.856 8.664 2 12.226 2c3.158 0 5.796 2.244 6.355 5.221c2.3.977 3.919 3.238 3.919 5.882c0 3.074-2.188 5.631-5.093 6.253a.75.75 0 0 1-.314-1.467c2.24-.48 3.907-2.446 3.907-4.786c0-2.137-1.39-3.962-3.338-4.628a5.018 5.018 0 0 0-1.626-.27c-.583 0-1.14.1-1.658.28a.75.75 0 0 1-.494-1.416a6.517 6.517 0 0 1 3.024-.305A4.962 4.962 0 0 0 12.226 3.5" />
             </svg>
           </button>
+          <div name="progress-download" id="progress-download"></div>
         </div>
         {{else}}
-        <div class="card-header" onclick="selectModel(this, '{{.Name}}')">{{.Name}}</div>
+        <div id="card-header-{{.Name}}" class="card-header" onclick="selectModel('{{.Name}}')">{{.Name}}</div>
         <div class="card-body tab-content mh-100" id="js-tabs-content-{{.Name}}">
           <!-- Tabs -->
           <ul class="nav nav-underline nav-fill mb-3 justify-content-center" id="js-tabs-{{.Name}}" role="tablist">
@@ -55,7 +56,7 @@
         </div>
         {{end}}
         {{else}}
-        <div class="card-header" onclick="selectModel(this, '{{.Name}}')">{{.Name}}</div>
+        <div class="card-header" onclick="selectModel('{{.Name}}')">{{.Name}}</div>
         <div class="card-body tab-content mh-100" id="js-tabs-content-{{.Name}}">
           <!-- Tabs -->
           <ul class="nav nav-underline nav-fill mb-3 justify-content-center" id="js-tabs-{{.Name}}" role="tablist">
@@ -116,8 +117,11 @@
       });
   }
 
-  async function selectModel(cardElement, modelName) {
-    console.log(modelName)
+  async function selectModel(modelName) {
+    
+    // Get the card element using the data-model-name attribute
+    let cardElement = document.querySelector(`div[data-model-name="${modelName}"]`);
+    
     cardElement.classList.toggle('card-selected');
 
     // Determine the action based on selection state

--- a/public/templates/model.html
+++ b/public/templates/model.html
@@ -6,7 +6,7 @@
   <div class="row">
     {{range .models}}
     <div class="col-6 gy-3">
-      <div class="card h-100" data-model-name="{{.Name}}" onclick="selectModel(this, '{{.Name}}')">
+      <div class="card h-100" data-model-name="{{.Name}}">
         <!-- If .Downloaded is false, add button to call download link -->
         {{if not .Downloaded}}
         {{if not (eq .Name "openai-gpt")}}
@@ -24,7 +24,7 @@
           </button>
         </div>
         {{else}}
-        <div class="card-header">{{.Name}}</div>
+        <div class="card-header" onclick="selectModel(this, '{{.Name}}')">{{.Name}}</div>
         <div class="card-body tab-content mh-100" id="js-tabs-content-{{.Name}}">
           <!-- Tabs -->
           <ul class="nav nav-underline nav-fill mb-3 justify-content-center" id="js-tabs-{{.Name}}" role="tablist">
@@ -55,7 +55,7 @@
         </div>
         {{end}}
         {{else}}
-        <div class="card-header">{{.Name}}</div>
+        <div class="card-header" onclick="selectModel(this, '{{.Name}}')">{{.Name}}</div>
         <div class="card-body tab-content mh-100" id="js-tabs-content-{{.Name}}">
           <!-- Tabs -->
           <ul class="nav nav-underline nav-fill mb-3 justify-content-center" id="js-tabs-{{.Name}}" role="tablist">
@@ -92,8 +92,10 @@
 </div>
 
 <script>
-  // download model
   async function downloadModel(modelName) {
+
+    // Append 
+
     console.log("Downloading model: ", modelName);
     
     // Fetch the download route
@@ -113,6 +115,7 @@
         console.error('Error:', error);
       });
   }
+
   async function selectModel(cardElement, modelName) {
     console.log(modelName)
     cardElement.classList.toggle('card-selected');


### PR DESCRIPTION
`webget` automatically fetches a valid URL that is input in the user prompt. For now, the best way to use it is to paste a URL first, then your prompt below and submit. Eternal will attempt to fetch relevant text content from the given URL and use it as reference for the prompt.

`websearch` must be toggled via the toolbar button and triggers a search engine workflow to retrieve the top 20 results for the given prompt, removes blacklisted URL's from the results, then returns the page content for the top result. This is limited to 1 result for now until we implement a more advanced summary and context management workflow.